### PR TITLE
fix(ci): skip nightly sprint cleanly when ANTHROPIC_API_KEY is unset

### DIFF
--- a/.aishore/lib/cmd-status.sh
+++ b/.aishore/lib/cmd-status.sh
@@ -207,7 +207,7 @@ _status_json() {
     jq -n --argjson total "$total" \
           --argjson todo "$todo" \
           --argjson in_progress "$in_progress" \
-          --argjson done "$done_count" \
+          --argjson "done" "$done_count" \
           --argjson ready "$ready" \
           --argjson failed "$failed" \
           '{total: $total, todo: $todo, in_progress: $in_progress, done: $done, ready: $ready, failed: $failed}'

--- a/.github/workflows/aishore.yml
+++ b/.github/workflows/aishore.yml
@@ -60,18 +60,35 @@ jobs:
     timeout-minutes: 120
 
     steps:
+      # Skip (instead of fail) when the API key secret hasn't been set up.
+      - name: Check for ANTHROPIC_API_KEY
+        id: key
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "::warning::ANTHROPIC_API_KEY secret is not set — skipping sprint. Add it under Settings → Secrets and variables → Actions to enable sprints."
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v6
+        if: steps.key.outputs.present == 'true'
         with:
           fetch-depth: 0  # full history for branching
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
+        if: steps.key.outputs.present == 'true'
         with:
           node-version: '22'
 
       - name: Install dependencies
+        if: steps.key.outputs.present == 'true'
         run: sudo apt-get update && sudo apt-get install -y jq
 
       - name: Run aishore
+        if: steps.key.outputs.present == 'true'
         uses: ./
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
The scheduled `aishore` workflow has failed every night for at least the past week because this repo has no `ANTHROPIC_API_KEY` secret — the action exits 1 with *"ANTHROPIC_API_KEY is required"*.

This adds a first step that checks whether the secret is present and, if not, skips the sprint with a `::warning` annotation instead of failing the run. Since this workflow also serves as the template users copy, the graceful skip improves the out-of-the-box experience for repos that haven't configured the secret yet.

Also bumps `actions/setup-node` v4 → v5, since v4 runs on Node 20 which GitHub force-migrates to Node 24 on June 16, 2026.

To actually run nightly sprints, add the secret: `gh secret set ANTHROPIC_API_KEY -R simonplant/aishore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)